### PR TITLE
Feature/cross team search

### DIFF
--- a/com/coralogix/tracing/v1/span.proto
+++ b/com/coralogix/tracing/v1/span.proto
@@ -19,4 +19,5 @@ message Span {
     repeated Log logs = 9;
     map<string, google.protobuf.StringValue> process_tags = 10;
     google.protobuf.BoolValue visible = 11;
+    google.protobuf.Int32Value company_id = 12;
 }

--- a/com/coralogix/tracing/v1/trace.proto
+++ b/com/coralogix/tracing/v1/trace.proto
@@ -15,4 +15,5 @@ message Trace {
     map<string, google.protobuf.StringValue> root_tags = 10;
     google.protobuf.BoolValue visible = 11;
     google.protobuf.BoolValue root_span_visible = 12;
+    google.protobuf.Int32Value company_id = 13;
 }

--- a/com/coralogix/tracing/v1/trace_query.proto
+++ b/com/coralogix/tracing/v1/trace_query.proto
@@ -48,7 +48,7 @@ message TracingQueryDefinition {
     google.protobuf.Int32Value size = 6;
     google.protobuf.Int32Value filter_size = 7;
     repeated TracingGraphDescriptor graphs = 8;
-    repeated google.protobuf.Int32Value companies = 9;
+    repeated google.protobuf.UInt32Value teams = 9;
 }
 
 message TracingQuery {

--- a/com/coralogix/tracing/v1/trace_query.proto
+++ b/com/coralogix/tracing/v1/trace_query.proto
@@ -48,6 +48,7 @@ message TracingQueryDefinition {
     google.protobuf.Int32Value size = 6;
     google.protobuf.Int32Value filter_size = 7;
     repeated TracingGraphDescriptor graphs = 8;
+    repeated google.protobuf.Int32Value companies = 9;
 }
 
 message TracingQuery {

--- a/com/coralogix/tracing/v1/tracing_service.proto
+++ b/com/coralogix/tracing/v1/tracing_service.proto
@@ -10,7 +10,7 @@ package com.coralogix.tracing.v1;
 
 message GetTraceRequest {
     google.protobuf.StringValue trace_id = 1; // required
-    repeated google.protobuf.Int32Value company_id = 2;
+    repeated google.protobuf.Int32Value team_id = 2;
 }
 
 message GetTraceResponse {
@@ -65,7 +65,7 @@ message GetTraceGraphResponse {
 
 message GetTraceTagsRequest {
     TraceQueryTimeRange time_range = 1;
-    repeated google.protobuf.Int32Value companies = 2;
+    repeated google.protobuf.UInt32Value teams = 2;
 }
 
 message GetTraceTagsResponse {

--- a/com/coralogix/tracing/v1/tracing_service.proto
+++ b/com/coralogix/tracing/v1/tracing_service.proto
@@ -51,6 +51,7 @@ message GetTraceFiltersResponse {
     repeated MetadataFilterField metadata_filters = 1;
     repeated TagFilterField tag_filters = 2;
     TraceQueryLatency latency_range = 3;
+    repeated FilterFieldValue teams = 4;
 }
 
 message GetTraceGraphRequest {

--- a/com/coralogix/tracing/v1/tracing_service.proto
+++ b/com/coralogix/tracing/v1/tracing_service.proto
@@ -10,7 +10,7 @@ package com.coralogix.tracing.v1;
 
 message GetTraceRequest {
     google.protobuf.StringValue trace_id = 1; // required
-    repeated google.protobuf.Int32Value team_id = 2;
+    google.protobuf.Int32Value team_id = 2;
 }
 
 message GetTraceResponse {

--- a/com/coralogix/tracing/v1/tracing_service.proto
+++ b/com/coralogix/tracing/v1/tracing_service.proto
@@ -10,6 +10,7 @@ package com.coralogix.tracing.v1;
 
 message GetTraceRequest {
     google.protobuf.StringValue trace_id = 1; // required
+    repeated google.protobuf.Int32Value company_id = 2;
 }
 
 message GetTraceResponse {
@@ -64,6 +65,7 @@ message GetTraceGraphResponse {
 
 message GetTraceTagsRequest {
     TraceQueryTimeRange time_range = 1;
+    repeated google.protobuf.Int32Value companies = 2;
 }
 
 message GetTraceTagsResponse {


### PR DESCRIPTION
## Technical description
we want to add support from users to query multiple teams tracing in a single request

## Solution
add support for requests to supply teams (or team_id in the case of single trace request)
this allows cross team search
we receive the teams scopes from the authentication header
validate that the user has permission to query the teams supplied
and add the other team indices when querying, along with adding filtering per scope per company, with the new
`metadata.companyId` in the span document
so the scopes of each team will be applied only on that team's spans

### Story link
https://app.shortcut.com/coralogix/story/2711/cross-team-search-be-same-as-log-screen
## Screenshot (optional)