### PR TITLE
Add CreateCachedQuery method.

### DIFF
--- a/com/coralogix/tracing/v1/tracing_internal_service.proto
+++ b/com/coralogix/tracing/v1/tracing_internal_service.proto
@@ -23,6 +23,14 @@ message GetTraceProcessTagsInternalResponse {
     repeated google.protobuf.StringValue tags = 3;
 }
 
+message CreateCachedTraceQueryInternalRequest {
+    TracingQueryDefinition query = 1;
+}
+
+message CreateCachedTraceQueryInternalResponse {
+    google.protobuf.StringValue query_id = 1;
+}
+
 service TracingInternalService {
     rpc GetTraceTagsInternal(GetTraceTagsInternalRequest) returns (GetTraceTagsInternalResponse) {
         option (audit_log_description).description = "get trace tags internal";
@@ -31,4 +39,9 @@ service TracingInternalService {
     rpc GetTraceProcessTagsInternal(GetTraceProcessTagsInternalRequest) returns (GetTraceProcessTagsInternalResponse) {
         option (audit_log_description).description = "get trace process tags internal";
     }
+
+    rpc CreateCachedTraceQueryInternal(CreateCachedTraceQueryInternalRequest) returns (CreateCachedTraceQueryInternalResponse) {
+        option (audit_log_description).description = "create cached trace query internal";
+    }
+
 }


### PR DESCRIPTION
### Descripton
In tracing alert slack notification we want to have a button that opens spans screen with related-spans-query.
After we construct the related-spans-query we need a way for user to open spans screen with it.
In order to do it we need to add method to `ws-tracing` that will cache query and return `query_id`. 
So slack button can redirect to `https://onlineboutique.coralogix.com/#/query-new/tracing?id={{query_id}}`

### Task
https://coralogix.atlassian.net/browse/FAST-776