### PR TITLE
Changing calling save cache to be the API caller responsibility

### DIFF
--- a/com/coralogix/tracing/v1/spans_service.proto
+++ b/com/coralogix/tracing/v1/spans_service.proto
@@ -68,6 +68,22 @@ message GetFullSpanDataResponse {
   repeated GetSpanGraphResponse span_graph_data = 4;
 }
 
+message GetCachedSpanQueryRequest {
+  google.protobuf.StringValue query_id = 1;
+}
+
+message GetCachedSpanQueryResponse {
+  SpanQueryDefinition query = 1;
+  google.protobuf.Int32Value saved_view_id = 2;
+}
+
+message SetCachedSpanQueryRequest {
+  google.protobuf.StringValue query_id = 1;
+  SpanQuery query = 2;
+}
+
+message SetCachedSpanQueryResponse {}
+
 service SpanService {
   rpc GetSpan(GetSpanRequest) returns (GetSpanResponse) {
     option (audit_log_description).description = "get span";
@@ -89,6 +105,12 @@ service SpanService {
   }
   rpc GetFullSpanData(GetFullSpanDataRequest) returns (GetFullSpanDataResponse) {
     option (audit_log_description).description = "get full span data";
+  }
+  rpc GetCachedSpanQuery(GetCachedSpanQueryRequest) returns (GetCachedSpanQueryResponse) {
+    option (audit_log_description).description = "get cached spans query";
+  }
+  rpc SetCachedSpanQuery(SetCachedSpanQueryRequest) returns (SetCachedSpanQueryResponse) {
+    option (audit_log_description).description = "set cached spans query";
   }
 }
 

--- a/com/coralogix/tracing/v1/tracing_service.proto
+++ b/com/coralogix/tracing/v1/tracing_service.proto
@@ -48,6 +48,13 @@ message GetCachedTraceQueryResponse {
     google.protobuf.Int32Value saved_view_id = 2;
 }
 
+message SetCachedTraceQueryRequest {
+    google.protobuf.StringValue query_id = 1;
+    TracingQuery query = 2;
+}
+
+message SetCachedTraceQueryResponse {}
+
 message GetTraceFiltersRequest {
     TracingQuery query = 1;
 }
@@ -133,5 +140,9 @@ service TracingService {
 
     rpc GetTraceLatencyPercentile(GetTraceLatencyPercentileRequest) returns (GetTraceLatencyPercentileResponse) {
         option (audit_log_description).description = "get trace latency";
+    }
+
+    rpc SetCachedTraceQuery(SetCachedTraceQueryRequest) returns (SetCachedTraceQueryResponse) {
+        option (audit_log_description).description = "set cached trace query";
     }
 }


### PR DESCRIPTION
In order to support both tracing and spans in the explore screen we need to be able differentiate between the queries in the query cache
https://coralogix.atlassian.net/browse/RDNT-160